### PR TITLE
python 3.14 rebuild

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = nwg-wrapper
 	pkgdesc = Wrapper to display a script output or a text file content on the desktop in sway or other wlroots-based compositors
 	pkgver = 0.1.3
-	pkgrel = 3
+	pkgrel = 9
 	url = https://github.com/nwg-piotr/nwg-wrapper
 	arch = x86_64
 	license = MIT

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Piotr Miller <nwg.piotr@gmail.com>
 pkgname=('nwg-wrapper')
 pkgver=0.1.3
-pkgrel=8
+pkgrel=9
 pkgdesc="Wrapper to display a script output or a text file content on the desktop in sway or other wlroots-based compositors"
 arch=('any')
 url="https://github.com/nwg-piotr/nwg-wrapper"


### PR DESCRIPTION
As python 3.14 is used already in the distro, package needs to be rebuilt